### PR TITLE
VXFM-2344 Allow deployOvf to function even when DNS is not fully configured.

### DIFF
--- a/lib/rbvmomi/vim/OvfManager.rb
+++ b/lib/rbvmomi/vim/OvfManager.rb
@@ -134,6 +134,7 @@ class RbVmomi::VIM::OvfManager
         end while i <= 5 && !ip
         raise "Couldn't get host's IP address" unless ip
         href = deviceUrl.url.gsub("*", ip)
+        href = href.gsub(URI.parse(href).host, ip)
         downloadCmd = "#{CURLBIN} -L '#{URI::escape(filename)}'"
         uploadCmd = "#{CURLBIN} -Ss -X #{method} --insecure -T - -H 'Content-Type: application/x-vnd.vmware-streamVmdk' '#{URI::escape(href)}'"
         # Previously we used to append "-H 'Content-Length: #{fileItem.size}'"


### PR DESCRIPTION
We observed an issue when hosts were added to vCenter via a FQDN, but
DNS was not functioning end to end in the environment, specifically at
the location where the deployOvf call was initiated.  Thus deploying an
Ovf failed.  This updates the upload command to always ensure a valid
location by IP even when DNS is not available at the calling location:w.